### PR TITLE
Fix client break for instant break blocks.

### DIFF
--- a/src/SenseiTarzan/SymplyPlugin/Listener/ClientBreakListener.php
+++ b/src/SenseiTarzan/SymplyPlugin/Listener/ClientBreakListener.php
@@ -23,15 +23,12 @@ declare(strict_types=1);
 
 namespace SenseiTarzan\SymplyPlugin\Listener;
 
-use pocketmine\block\Block;
 use pocketmine\event\EventPriority;
 use pocketmine\event\server\DataPacketReceiveEvent;
 use pocketmine\math\Vector3;
 use pocketmine\network\mcpe\NetworkSession;
-use pocketmine\network\mcpe\protocol\InventoryTransactionPacket;
 use pocketmine\network\mcpe\protocol\LevelEventPacket;
 use pocketmine\network\mcpe\protocol\PlayerAuthInputPacket;
-use pocketmine\network\mcpe\protocol\types\inventory\UseItemTransactionData;
 use pocketmine\network\mcpe\protocol\types\LevelEvent;
 use pocketmine\network\mcpe\protocol\types\PlayerAction;
 use pocketmine\network\mcpe\protocol\types\PlayerBlockAction;
@@ -49,124 +46,146 @@ use function floor;
 
 class ClientBreakListener
 {
-	/** @phpstan-var WeakMap<NetworkSession, BlockBreakRequest> */
-	private WeakMap $breaks;
+    /** @phpstan-var WeakMap<NetworkSession, BlockBreakRequest> */
+    private WeakMap $breaks;
 
-	const MAX_DISTANCE_BREAK = 16 ** 2;
+    const MAX_DISTANCE_BREAK = 16 ** 2;
 
-	public function __construct()
-	{
-		$this->breaks = new WeakMap();
-	}
+    public function __construct()
+    {
+        $this->breaks = new WeakMap();
+    }
 
-	#[EventAttribute(EventPriority::MONITOR)]
-	public function onDataReceive(DataPacketReceiveEvent $event) : void
-	{
-		$player = ($session = $event->getOrigin())->getPlayer();
-		if ($player === null || $player->isCreative())
-			return;
-		$packet = $event->getPacket();
-		if($packet instanceof PlayerAuthInputPacket) {
-			$cancel = false;
-			$blockActions = $packet->getBlockActions();
-			if ($blockActions !== null) {
-				if (count($blockActions) > 100) {
-					$session->getLogger()->debug("PlayerAuthInputPacket contains " . count($blockActions) . " block actions, dropping");
-					return;
-				}
-				/**
-				 * @var int $k
-				 * @var PlayerBlockAction $blockAction
-				 */
-				foreach ($blockActions as $index => $blockAction) {
-					$action = $blockAction->getActionType();
-					if ($blockAction instanceof PlayerBlockActionWithBlockInfo) {
-						if ($action === PlayerAction::START_BREAK) {
-							$vector3 = new Vector3($blockAction->getBlockPosition()->getX(), $blockAction->getBlockPosition()->getY(), $blockAction->getBlockPosition()->getZ());
-							$block = $player->getWorld()->getBlock($vector3);
-							if ($block->getBreakInfo()->breaksInstantly())
-								continue;
-							$speed = BlockUtils::getDestroyRate($player, $block);
-							$this->breaks->offsetSet($session, new BlockBreakRequest($player->getWorld(), $vector3, $speed));
+    #[EventAttribute(EventPriority::MONITOR)]
+    public function onDataReceive(DataPacketReceiveEvent $event): void
+    {
+        $player = ($session = $event->getOrigin())->getPlayer();
+        if ($player === null || $player->isCreative())
+            return;
 
-							if(!$player->attackBlock($vector3, $blockAction->getFace()))
-							{
-								$this->onFailedBlockAction($session, $player, $vector3, $blockAction->getFace());
-							}else {
-								$player->getWorld()->broadcastPacketToViewers(
-									$vector3,
-									LevelEventPacket::create(LevelEvent::BLOCK_START_BREAK, (int) floor($speed * 65535.0), $vector3)
-								);
-							}
-							unset($blockActions[$index]);
-						} elseif ($action === PlayerAction::CRACK_BREAK) {
-							if ($this->breaks->offsetExists($session)) {
-								$vector3 = new Vector3($blockAction->getBlockPosition()->getX(), $blockAction->getBlockPosition()->getY(), $blockAction->getBlockPosition()->getZ());
-								$block = $player->getWorld()->getBlock($vector3);
-								$breakRequest = $this->breaks->offsetGet($session);
-								if ($vector3->distanceSquared($breakRequest->getOrigin()) > self::MAX_DISTANCE_BREAK) {
-									unset($this->breaks[$session]);
-									continue;
-								}
-								if ($breakRequest->addTick(BlockUtils::getDestroyRate($player, $block)) >= 1) {
-									$player->breakBlock($vector3);
-									unset($this->breaks[$session]);
-								}
-							}
-							unset($blockActions[$index]);
-						} elseif ($blockAction->getActionType() === PlayerAction::ABORT_BREAK) {
-							$vector3 = new Vector3($blockAction->getBlockPosition()->getX(), $blockAction->getBlockPosition()->getY(), $blockAction->getBlockPosition()->getZ());
-							if ($this->breaks->offsetExists($session)) {
-								$player->stopBreakBlock($vector3);
-								unset($this->breaks[$session]);
-							}
-							unset($blockActions[$index]);
-						}
-					} elseif ($blockAction instanceof PlayerBlockActionStopBreak) {
-						if ($this->breaks->offsetExists($session)) {
-							unset($this->breaks[$session]);
-						}
-					}
-				}
-				(new ReflectionProperty($packet, "blockActions"))->setValue($packet, $blockActions);
-			}
-		}/*else if($packet instanceof  InventoryTransactionPacket){
-			$data = $packet->trData;
-			if ($data instanceof UseItemTransactionData && $data->getActionType() === UseItemTransactionData::ACTION_BREAK_BLOCK){
-				if ($this->breaks->offsetExists($session)){
-					$breakRequest = $this->breaks->offsetGet($session);
-					$blockPos = $data->getBlockPosition();
-					$vBlockPos = new Vector3($blockPos->getX(), $blockPos->getY(), $blockPos->getZ());
-					if ($vBlockPos->distanceSquared($breakRequest->getOrigin()) > self::MAX_DISTANCE_BREAK) {
-						$this->breaks->offsetUnset($session);
-						return;
-					}
-					if(floor($breakRequest->getStart()) < 1) {
-						$this->onFailedBlockAction($session, $player, $vBlockPos, null);
-							$event->cancel();
-					}
-				}
-			}
-		}*/
-	}
+        $packet = $event->getPacket();
+        if ($packet instanceof PlayerAuthInputPacket) {
+            $blockActions = $packet->getBlockActions();
+            if ($blockActions !== null) {
+                if (count($blockActions) > 100) {
+                    $session->getLogger()->debug("PlayerAuthInputPacket contains " . count($blockActions) . " block actions, dropping");
+                    return;
+                }
 
-	/**
-	 * Internal function used to execute rollbacks when an action fails on a block.
-	 */
-	private function onFailedBlockAction(NetworkSession $session, Player $player, Vector3 $blockPos, ?int $face) : void{
-		if($blockPos->distanceSquared($player->getLocation()) < 10000){
-			$blocks = $blockPos->sidesArray();
-			if($face !== null){
-				$sidePos = $blockPos->getSide($face);
+                /**
+                 * @var int $index
+                 * @var PlayerBlockAction $blockAction
+                 */
+                foreach ($blockActions as $index => $blockAction) {
+                    $action = $blockAction->getActionType();
 
-				/** @var Vector3[] $blocks */
-				array_push($blocks, ...$sidePos->sidesArray()); //getAllSides() on each of these will include $blockPos and $sidePos because they are next to each other
-			}else{
-				$blocks[] = $blockPos;
-			}
-			foreach($player->getWorld()->createBlockUpdatePackets($blocks) as $packet){
-				$session->sendDataPacket($packet);
-			}
-		}
-	}
+                    if ($blockAction instanceof PlayerBlockActionWithBlockInfo) {
+                        if ($action === PlayerAction::START_BREAK) {
+                            $vector3 = new Vector3(
+                                $blockAction->getBlockPosition()->getX(),
+                                $blockAction->getBlockPosition()->getY(),
+                                $blockAction->getBlockPosition()->getZ()
+                            );
+                            $block = $player->getWorld()->getBlock($vector3);
+
+                            if ($block->getBreakInfo()->breaksInstantly()) {
+                                if ($player->attackBlock($vector3, $blockAction->getFace())) {
+                                    $player->breakBlock($vector3);
+                                } else {
+                                    $this->onFailedBlockAction($session, $player, $vector3, $blockAction->getFace());
+                                }
+                                unset($blockActions[$index]);
+                                continue;
+                            }
+
+                            $speed = BlockUtils::getDestroyRate($player, $block);
+                            $this->breaks->offsetSet($session, new BlockBreakRequest($player->getWorld(), $vector3, $speed));
+
+                            if (!$player->attackBlock($vector3, $blockAction->getFace())) {
+                                $this->onFailedBlockAction($session, $player, $vector3, $blockAction->getFace());
+                            } else {
+                                $player->getWorld()->broadcastPacketToViewers(
+                                    $vector3,
+                                    LevelEventPacket::create(LevelEvent::BLOCK_START_BREAK, (int)floor($speed * 65535.0), $vector3)
+                                );
+                            }
+                            unset($blockActions[$index]);
+
+                        } elseif ($action === PlayerAction::CRACK_BREAK) {
+                            if ($this->breaks->offsetExists($session)) {
+                                $vector3 = new Vector3(
+                                    $blockAction->getBlockPosition()->getX(),
+                                    $blockAction->getBlockPosition()->getY(),
+                                    $blockAction->getBlockPosition()->getZ()
+                                );
+                                $block = $player->getWorld()->getBlock($vector3);
+                                $breakRequest = $this->breaks->offsetGet($session);
+
+                                if ($vector3->distanceSquared($breakRequest->getOrigin()) > self::MAX_DISTANCE_BREAK) {
+                                    unset($this->breaks[$session]);
+                                    continue;
+                                }
+
+                                if ($breakRequest->addTick(BlockUtils::getDestroyRate($player, $block)) >= 1) {
+                                    $player->breakBlock($vector3);
+                                    unset($this->breaks[$session]);
+                                }
+                            }
+                            unset($blockActions[$index]);
+
+                        } elseif ($action === PlayerAction::ABORT_BREAK) {
+                            $vector3 = new Vector3(
+                                $blockAction->getBlockPosition()->getX(),
+                                $blockAction->getBlockPosition()->getY(),
+                                $blockAction->getBlockPosition()->getZ()
+                            );
+                            if ($this->breaks->offsetExists($session)) {
+                                $player->stopBreakBlock($vector3);
+                                unset($this->breaks[$session]);
+                            }
+                            unset($blockActions[$index]);
+
+                        } elseif ($action === PlayerAction::STOP_BREAK) {
+                            if ($this->breaks->offsetExists($session)) {
+                                $breakRequest = $this->breaks->offsetGet($session);
+                                $player->stopBreakBlock($breakRequest->getOrigin());
+                                unset($this->breaks[$session]);
+                            }
+                            unset($blockActions[$index]);
+                        }
+
+                    } elseif ($blockAction instanceof PlayerBlockActionStopBreak) {
+                        if ($this->breaks->offsetExists($session)) {
+                            $breakRequest = $this->breaks->offsetGet($session);
+                            $player->stopBreakBlock($breakRequest->getOrigin());
+                            unset($this->breaks[$session]);
+                        }
+                        unset($blockActions[$index]);
+                    }
+                }
+
+                (new ReflectionProperty($packet, "blockActions"))->setValue($packet, $blockActions);
+            }
+        }
+    }
+
+    /**
+     * Internal function used to execute rollbacks when an action fails on a block.
+     */
+    private function onFailedBlockAction(NetworkSession $session, Player $player, Vector3 $blockPos, ?int $face): void
+    {
+        if ($blockPos->distanceSquared($player->getLocation()) < 10000) {
+            $blocks = $blockPos->sidesArray();
+            if ($face !== null) {
+                $sidePos = $blockPos->getSide($face);
+                /** @var Vector3[] $blocks */
+                array_push($blocks, ...$sidePos->sidesArray()); //getAllSides() on each of these will include $blockPos and $sidePos because they are next to each other
+            } else {
+                $blocks[] = $blockPos;
+            }
+            foreach ($player->getWorld()->createBlockUpdatePackets($blocks) as $packet) {
+                $session->sendDataPacket($packet);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Problème principal résolu : Blocs instantanés :
```php
// AVANT
if ($block->getBreakInfo()->breaksInstantly())
    continue; // Ignore complètement l'action serveur.

// APRÈS (corrigé)
if ($block->getBreakInfo()->breaksInstantly()) {
    if ($player->attackBlock($vector3, $blockAction->getFace())) {
        $player->breakBlock($vector3); // Synchronise avec le client.
    } else {
        $this->onFailedBlockAction($session, $player, $vector3, $blockAction->getFace());
    }
    unset($blockActions[$index]);
    continue;
}
```

```php
// AVANT
elseif($blockAction->getActionType() === PlayerAction::STOP_BREAK) 
    $event->cancel(); // Cancel tout l'événement.

// APRÈS (corrigé)
elseif ($action === PlayerAction::STOP_BREAK) {
    if ($this->breaks->offsetExists($session)) {
        $breakRequest = $this->breaks->offsetGet($session);
        $player->stopBreakBlock($breakRequest->getOrigin()); // Arrêt propre ?
        unset($this->breaks[$session]);
    }
    unset($blockActions[$index]);
}
```

```php
// Maintenant appelle également stopBreakBlock() pour un arrêt propre ?
elseif ($blockAction instanceof PlayerBlockActionStopBreak) {
    if ($this->breaks->offsetExists($session)) {
        $breakRequest = $this->breaks->offsetGet($session);
        $player->stopBreakBlock($breakRequest->getOrigin()); // Arrêt propre ?
        unset($this->breaks[$session]);
    }
    unset($blockActions[$index]);
}
```